### PR TITLE
Replaced vulnerable functions and outdated dependencies

### DIFF
--- a/wxpy/ext/xiaoi.py
+++ b/wxpy/ext/xiaoi.py
@@ -63,12 +63,12 @@ class XiaoI(object):
         nonce = "4103657107305326101203516108016101205331"
 
         sha1 = "{0}:{1}:{2}".format(self.key, self.realm, self.secret).encode("utf-8")
-        sha1 = hashlib.sha1(sha1).hexdigest()
+        sha1 = hashlib.sha512(sha1).hexdigest()
         sha2 = "{0}:{1}".format(self.http_method, self.uri).encode("utf-8")
-        sha2 = hashlib.sha1(sha2).hexdigest()
+        sha2 = hashlib.sha512(sha2).hexdigest()
 
         signature = "{0}:{1}:{2}".format(sha1, nonce, sha2).encode("utf-8")
-        signature = hashlib.sha1(signature).hexdigest()
+        signature = hashlib.sha512(signature).hexdigest()
 
         ret = collections.namedtuple("signature_return", "signature nonce")
         ret.signature = signature


### PR DESCRIPTION

Potential vulnerability risks were detected in your dependencies and used functions.
                    Some vulnerabilities have been replaced by safe alternatives. 

# Vulnerable Functions 
*puid_map.py:143:76:* pickle.load
* Reason: Untrusted input can result in arbitrary code execution.
* Severity: warning


*xiaoi.py:66:15:* hashlib.sha1
* Reason: Attacks can find collisions in the full version of SHA-1.
* Replacement: hashlib.sha512()
* Severity: critical


*xiaoi.py:68:15:* hashlib.sha1
* Reason: Attacks can find collisions in the full version of SHA-1.
* Replacement: hashlib.sha512()
* Severity: critical


*xiaoi.py:71:20:* hashlib.sha1
* Reason: Attacks can find collisions in the full version of SHA-1.
* Replacement: hashlib.sha512()
* Severity: critical


# Vulnerable Dependencies 
Some versions of dependencies used in the project might pose security threads. Please make sure to inform users to use safe versions. 

| Dependency  | Vulnerable Versions | Reason | 
| --------------| -------------------- | ------- | 
|setuptools|<0.9.5|setuptools 0.9.5 fixes a security vulnerability in SSL certificate validation.|
|setuptools|<1.3|setuptools before 1.3 has a security vulnerability in SSL match_hostname check as reported in Python 17997.|
|setuptools|<3.0|setuptools 3.0 avoids the potential security vulnerabilities presented by use of tar archives in ez_setup.py. It also leverages the security features added to ZipFile.extract in Python 2.7.4.|
|requests|<2.3.0|requests before 2.3.0 exposes Authorization or Proxy-Authorization headers on redirect.  Fix CVE-2014-1829 and CVE-2014-1830 respectively|
|requests|<2.6.0|requests 2.6.0 fixes handling of cookies on redirect. Previously a cookie without a host value set would use the hostname for the redirected URL exposing requests users to session fixation attacks and potentially cookie stealing.|
|requests|>=2.1,<=2.5.3|The resolve_redirects function in sessions.py in requests 2.1.0 through 2.5.3 allows remote attackers to conduct session fixation attacks via a cookie without a host value in a redirect.|

Source: [Safety](https://github.com/pyupio/safety) 

# Test Report 
No tests found or tests could not be executed
 
 
 --- 
 
This tool was developed as part of a Software Engineering course. The intention is to make project maintainers aware of potential vulnerabilities. If you have feedback then please reply to this pull-request. Thank you!